### PR TITLE
changle supported version for driver

### DIFF
--- a/packages/web_drivers/lib/chrome_driver_installer.dart
+++ b/packages/web_drivers/lib/chrome_driver_installer.dart
@@ -60,7 +60,7 @@ class ChromeDriverInstaller {
     bool successfulInstall = false;
     final int chromeVersion = await _querySystemChromeVersion();
 
-    if (chromeVersion == null || chromeVersion < 79) {
+    if (chromeVersion == null || chromeVersion < 78) {
       throw Exception('Unsupported Chrome version: $chromeVersion');
     }
 


### PR DESCRIPTION
We added a driver version mapping in the previous PR: https://github.com/flutter/web_installers/pull/4

Update the value in the check.