### PR TITLE
Changing chrome 81 driver

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,7 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
-  81: '81.0.4044.20'
+  81: '81.0.4044.69'
   80: '80.0.3987.106'
   79: '79.0.3945.36'
   78: '78.0.3904.105'

--- a/packages/web_drivers/lib/chrome_driver_installer.dart
+++ b/packages/web_drivers/lib/chrome_driver_installer.dart
@@ -101,6 +101,8 @@ class ChromeDriverInstaller {
     // The output looks like: Google Chrome 79.0.3945.36.
     final String output = versionResult.stdout as String;
 
+    print('INFO: chrome version in use $output');
+
     // Version number such as 79.0.3945.36.
     final String versionAsString = output.split(' ')[2];
 


### PR DESCRIPTION
The driver got out of sync in running cirrus ci tests:https://cirrus-ci.com/task/5458676014120960?command=main#L75

Changing the driver version for browser 81 also printing out to chrome version just in case to see which cirrus/luci instances are using which version

