### PR TITLE
Adding code for safari driver

### DIFF
--- a/packages/web_drivers/README.md
+++ b/packages/web_drivers/README.md
@@ -18,6 +18,15 @@
 
 ```dart lib/web_driver_installer.dart chromedriver --install-only```
 
+**To enable and start Safari Driver.**
+
+```dart lib/web_driver_installer.dart safaridriver```
+
+**Start a specific version of the driver.**
+This will end with an error if the exiting verison differs from the system version. This is useful for failing fast when on running on CI environments to see if the expected version is installed.
+
+```dart lib/web_driver_installer.dart safaridriver --driver-version="13.0.5"```
+
 **No-options also currently defaults to install and start Chrome Driver. It will be deprecated soon.**
 
 ```dart lib/web_driver_installer.dart &```

--- a/packages/web_drivers/lib/chrome_driver_command.dart
+++ b/packages/web_drivers/lib/chrome_driver_command.dart
@@ -5,7 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:web_driver_installer/chrome_driver_installer.dart';
 
-// Wrapper class on top of ChromeDriverInstaller to use it as a command.
+/// Wrapper class on top of [ChromeDriverInstaller] to use it as a command.
 class ChromeDriverCommand extends Command<bool> {
   @override
   String get description => 'Chrome Driver installer.';

--- a/packages/web_drivers/lib/safari_driver_command.dart
+++ b/packages/web_drivers/lib/safari_driver_command.dart
@@ -1,0 +1,41 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:web_driver_installer/safari_driver_runner.dart';
+
+/// Wrapper class on top of [SafariDriverRunner] to use it as a command.
+class SafariDriverCommand extends Command<bool> {
+  @override
+  String get description => 'Safari Driver runner.';
+
+  @override
+  String get name => 'safaridriver';
+
+  /// If the version is provided as an argument, it is checked against the
+  /// system version and an exception is thrown if they do not match.
+  final String defaultDriverVersion = 'system';
+
+  SafariDriverCommand() {
+    argParser
+      ..addOption('driver-version',
+          defaultsTo: defaultDriverVersion,
+          help: 'Run the given version of the driver. If the given version '
+              'does not exists throw an error.');
+  }
+
+  final SafariDriverRunner safariDriverRunner = SafariDriverRunner();
+
+  @override
+  Future<bool> run() async {
+    final String driverVersion = argResults['driver-version'];
+    try {
+      await safariDriverRunner.start(version: driverVersion);
+      return true;
+    } catch (e) {
+      print('Exception during running the safari driver: ${e.message}');
+      return false;
+    }
+  }
+}

--- a/packages/web_drivers/lib/safari_driver_runner.dart
+++ b/packages/web_drivers/lib/safari_driver_runner.dart
@@ -1,0 +1,88 @@
+/// Running Safari Driver which comes installed in every MacOS operation system.
+///
+/// The version of driver is the same as the version of the Safari installed
+/// in the system.
+import 'dart:io' as io;
+
+class SafariDriverRunner {
+  /// Start Safari Driver installed in the MacOS operating system.
+  ///
+  /// If a specific version is requested, it will check the existing system
+  /// version and throw and exception the versions do not match.
+  ///
+  /// If the operating system is not MacOS, the method will throw an exception.
+  Future<void> start({String version}) async {
+    if (!io.Platform.isMacOS) {
+      throw AssertionError('The operating system should be MacOS: '
+          '${io.Platform.operatingSystem}');
+    }
+    final io.Process process = await runDriver(version: version);
+    final int exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('Driver failed with exitcode: $exitCode');
+    }
+  }
+
+  /// Safari Driver needs to be enabled before it is used.
+  ///
+  /// The driver will need to get re-enabled after the machine is restarted.
+  ///
+  /// The enabling waits for user input for authentication.
+  void _enableDriver() {
+    io.Process.runSync('//usr/bin/safaridriver', ['--enable']);
+  }
+
+  /// Compare the version of the installed driver to the requested version.
+  ///
+  /// Throw an exception if they don't match.
+  Future<void> _compareDriverVersion(String version) async {
+    io.Process.run('//usr/bin/safaridriver', ['--version']);
+
+    final io.ProcessResult versionResult =
+        await io.Process.run('//usr/bin/safaridriver', ['--version']);
+
+    if (versionResult.exitCode != 0) {
+      throw Exception('Failed to get the safari driver version.');
+    }
+    // The output generally looks like: Included with Safari 13.0.5 (14608.5.12)
+    final String output = versionResult.stdout as String;
+    final String rest =
+        output.substring(output.indexOf('Safari'));
+
+    print('INFO: driver version in the system: $rest');
+
+    // Version number such as 13.0.5.
+    final String versionAsString = rest.trim().split(' ')[1];
+
+    if (versionAsString != version) {
+      throw Exception('System version $versionAsString not match requested '
+          'version $version');
+    }
+  }
+
+  /// Run Safari Driver installed in the MacOS operating system and return
+  /// the Process.
+  ///
+  /// Returns a [:Future<Process>:] that completes with a
+  /// Process instance when the process has been successfully
+  /// started. That [Process] object can be used to interact with the
+  /// process. If the process cannot be started the returned [Future]
+  /// completes with an exception.
+  ///
+  /// If a specific version is requested, it will check the existing system
+  /// version and throw and exception the versions do not match.
+  Future<io.Process> runDriver({String version = 'system'}) async {
+    _enableDriver();
+    if (version != 'system') {
+      await _compareDriverVersion(version);
+      print('INFO: Safari Driver will start with version $version on port '
+          '4444');
+    } else {
+      // Driver does not have any output.
+      // Printing this one as a info message.
+      print('INFO: Safari Driver will start on port 4444.');
+    }
+
+    return io.Process.start('//usr/bin/safaridriver', ['--port=4444']);
+  }
+}

--- a/packages/web_drivers/lib/web_driver_installer.dart
+++ b/packages/web_drivers/lib/web_driver_installer.dart
@@ -7,12 +7,15 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 
 import 'chrome_driver_command.dart';
+import 'safari_driver_command.dart';
 
 CommandRunner runner = CommandRunner<bool>(
   'webdriver-install',
   'Command-line utility for installing web drivers for web integration tests '
       'with flutter driver.',
-)..addCommand(ChromeDriverCommand());
+)
+  ..addCommand(ChromeDriverCommand())
+  ..addCommand(SafariDriverCommand());
 
 void main(List<String> args) async {
   // TODO(nurhan): Add more browsers' drivers. Control with command line args.
@@ -20,7 +23,7 @@ void main(List<String> args) async {
     // For now add chromedriver if no argument exists. This is not to break
     // exisiting tests.
     // TODO(nurhan): Fix smoke test in flutter to pass chromedriver as an arg.
-    if(args == null || args.length ==0) {
+    if (args == null || args.length == 0) {
       await runner.run(List<String>()..add('chromedriver'));
     } else {
       await runner.run(args);


### PR DESCRIPTION
Adding code for safari driver:
- run it as a script from command line
- run it as a library. returns the process so the parent can close it when the tests finish.
- have a version parameter. It will be useful for enforcing a version to the CI. If the version of Safari changes without our knowledge we can fast fail.

This PR will also be used in PR: https://github.com/flutter/engine/pull/17454

Fixes https://github.com/flutter/flutter/issues/53689