### PR TITLE
adding a new library for managing simulators

### DIFF
--- a/packages/simulators/README.md
+++ b/packages/simulators/README.md
@@ -2,43 +2,39 @@
 
 Simulators is a set of libraries for controlling mobile simulators/emulators. Currently there is support for iOS Simulators.
 
-## What can I use Simulators for
+## What can I use Simulators library for
 
-Currently only `IosSimulatorManager` is implemented. It can be used for:
+Currently only iOS is supported. There are two main classes `IosSimulator` and `IosSimulatorManager`. `IosSimulatorManager` can be used for accesing `IosSimulator` instances.
 
-1. **create**: Creates an iOS Simulator for given iOS version and phone name:
+1. Creating an iOS Simulator for given iOS version and phone name:
 
 ```
 IosSimulatorManager simulatorManager = IosSimulatorManager();
-IosSimulator id =
+IosSimulator simulator =
     await simulatorManager.createSimulator(13, 5, 'iPad mini 4');
 ```
 
-2. **boot**: Boots the iOS Simulator that's id is given:
+2. Get an existing simulator, given the iOS version and the phone name:
+
 
 ```
 IosSimulatorManager simulatorManager = IosSimulatorManager();
-await simulatorManager.bootSimulator('D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC' /* Simulator id*/);
+IosSimulator simulator =
+    await simulatorManager.getSimulator(13, 1, 'iPhone 11 Pro');
 ```
 
-3. **shutdown**: Shutsdown the iOS Simulator that's id is given:
+`IosSimulator` can be used to boot and shutdown a simulator. It's constructor is private. It can be created using `IosSimulatorManager` methods.
+
+1. **boot**: Boots the iOS Simulator:
 
 ```
-IosSimulatorManager simulatorManager = IosSimulatorManager();
-await simulatorManager.shutdownSimulator('D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC'/* Simulator id*/);
+IosSimulator simulator =
+    await simulatorManager.getSimulator(13, 1, 'iPhone 11 Pro');
+await simulator.boot();
 ```
 
-4. **getInformation**: Get the id and status of a simulator, given the iOS version and the phone name:
+2. **shutdown**: Shutsdown the iOS Simulator that's id is given:
 
 ```
-IosSimulatorManager simulatorManager = IosSimulatorManager();
-IosSimulator result =
-    await simulatorManager.getSimulatorInfo(13, 1, 'iPhone 11 Pro');
-```
-
-5. **list**: List the existing simulators for a given iOS version:
-
-```
-IosSimulatorManager simulatorManager = IosSimulatorManager();
-String output = await simulatorManager.listExistingSimulators(13,3);
+await simulator.shutdown();
 ```

--- a/packages/simulators/README.md
+++ b/packages/simulators/README.md
@@ -1,10 +1,13 @@
 ## What is Simulators
 
-Simulators is a set of libraries for controlling mobile simulators/emulators. Currently there is support for iOS Simulators.
+Simulators is a set of libraries for controlling mobile simulators/emulators.
+Currently there is support for iOS Simulators.
 
 ## What can I use Simulators library for
 
-Currently only iOS is supported. There are two main classes `IosSimulator` and `IosSimulatorManager`. `IosSimulatorManager` can be used for accesing `IosSimulator` instances.
+Currently only iOS is supported. There are two main classes `IosSimulator` and
+`IosSimulatorManager`. `IosSimulatorManager` can be used for accesing `IosSimulator`
+instances.
 
 1. Creating an iOS Simulator for given iOS version and phone name:
 
@@ -23,7 +26,8 @@ IosSimulator simulator =
     await simulatorManager.getSimulator(13, 1, 'iPhone 11 Pro');
 ```
 
-`IosSimulator` can be used to boot and shutdown a simulator. It's constructor is private. It can be created using `IosSimulatorManager` methods.
+`IosSimulator` can be used to boot and shutdown a simulator. It's constructor is private.
+It can be created using `IosSimulatorManager` methods.
 
 1. **boot**: Boots the iOS Simulator:
 

--- a/packages/simulators/README.md
+++ b/packages/simulators/README.md
@@ -1,0 +1,44 @@
+## What is Simulators
+
+Simulators is a set of libraries for controlling mobile simulators/emulators. Currently there is support for iOS Simulators.
+
+## What can I use Simulators for
+
+Currently only `IosSimulatorManager` is implemented. It can be used for:
+
+1. **create**: Creates an iOS Simulator for given iOS version and phone name:
+
+```
+IosSimulatorManager simulatorManager = IosSimulatorManager();
+IosSimulator id =
+    await simulatorManager.createSimulator(13, 5, 'iPad mini 4');
+```
+
+2. **boot**: Boots the iOS Simulator that's id is given:
+
+```
+IosSimulatorManager simulatorManager = IosSimulatorManager();
+await simulatorManager.bootSimulator('D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC' /* Simulator id*/);
+```
+
+3. **shutdown**: Shutsdown the iOS Simulator that's id is given:
+
+```
+IosSimulatorManager simulatorManager = IosSimulatorManager();
+await simulatorManager.shutdownSimulator('D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC'/* Simulator id*/);
+```
+
+4. **getInformation**: Get the id and status of a simulator, given the iOS version and the phone name:
+
+```
+IosSimulatorManager simulatorManager = IosSimulatorManager();
+IosSimulator result =
+    await simulatorManager.getSimulatorInfo(13, 1, 'iPhone 11 Pro');
+```
+
+5. **list**: List the existing simulators for a given iOS version:
+
+```
+IosSimulatorManager simulatorManager = IosSimulatorManager();
+String output = await simulatorManager.listExistingSimulators(13,3);
+```

--- a/packages/simulators/lib/simulator_manager.dart
+++ b/packages/simulators/lib/simulator_manager.dart
@@ -16,7 +16,7 @@ class IosSimulatorManager {
   IosSimulatorManager() {
     if (!io.Platform.isMacOS) {
       throw Exception('Platform ${io.Platform.operatingSystem} is not supported'
-          '. This class should only be used on MacOS. It uses xcrun '
+          '. This class should only be used on macOS. It uses xcrun '
           'simctl command line tool to manage the iOS simulators');
     }
   }
@@ -24,11 +24,11 @@ class IosSimulatorManager {
   /// Uses `xcrun simctl create` command to create an iOS Simulator.
   ///
   /// Runs `xcrun simctl list runtimes` to list the runtimes existing on your
-  /// MacOs. If runtime derived from [majorVersion] and [minorVersion] is not
+  /// macOS. If runtime derived from [majorVersion] and [minorVersion] is not
   /// available an exception will be thrown. Use Xcode to install more versions.
   ///
   /// [device] example iPhone 11 Pro. Run `xcrun simctl list devicetypes` to
-  /// list the devidetypes available. If [device] is not available, an
+  /// list the device types available. If [device] is not available, an
   /// exception will be thrown. Use Xcode to install more versions.
   ///
   /// Use `xcrun simctl create --help` for more details.
@@ -165,42 +165,41 @@ class IosSimulatorManager {
 
 /// A class that can be used to boot/shutdown an iOS Simulator.
 class IosSimulator {
-  final String _id;
-  String get id => _id;
+  final String id;
 
   bool _booted;
   bool get booted => _booted;
 
-  IosSimulator._(this._booted, this._id);
+  IosSimulator._(this._booted, this.id);
 
-  /// Boots the iOS Simulator using the simulator [_id].
+  /// Boots the iOS Simulator using the simulator [id].
   ///
   /// Uses `xcrun simctl boot` command to boot an iOS Simulator.
   ///
   /// If it is already booted the command will fail.
   Future<void> boot() async {
     final io.ProcessResult versionResult =
-        await io.Process.run('xcrun', ['simctl', 'boot', '$_id']);
+        await io.Process.run('xcrun', ['simctl', 'boot', '$id']);
 
     if (versionResult.exitCode != 0) {
-      throw Exception('Failed to boot iOS simulators with id: $_id.');
+      throw Exception('Failed to boot iOS simulators with id: $id.');
     }
     this._booted = true;
     return;
   }
 
-  /// Shutsdown the iOS Simulator using the simulator [_id].
+  /// Shuts down the iOS Simulator using the simulator [id].
   ///
   /// Uses `xcrun simctl shutdown` command to boot an iOS Simulator.
   ///
   /// If the simulator is not booted, the command will fail.
   Future<void> shutdown() async {
     final io.ProcessResult versionResult =
-        await io.Process.run('xcrun', ['simctl', 'shutdown', '$_id']);
+        await io.Process.run('xcrun', ['simctl', 'shutdown', '$id']);
 
     if (versionResult.exitCode != 0) {
       throw Exception(
-          'Failed to shutdown iOS simulators with id: $_id.');
+          'Failed to shutdown iOS simulators with id: $id.');
     }
 
     this._booted = false;
@@ -209,6 +208,6 @@ class IosSimulator {
 
   @override
   String toString() {
-    return 'iOS Simulator id: $_id status: $booted';
+    return 'iOS Simulator id: $id status: $booted';
   }
 }

--- a/packages/simulators/lib/simulator_manager.dart
+++ b/packages/simulators/lib/simulator_manager.dart
@@ -1,0 +1,192 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+/// Creates/boots/shutsdown/lists iOS Simulators.
+///
+/// Uses `xcrun simctl` command to manage the simulators.
+///
+/// Run `xcrun simctl --help` to learn more on the details of this tool.
+class IosSimulatorManager {
+  /// Uses `xcrun simctl create` command to create an iOS Simulator.
+  ///
+  /// Runs `xcrun simctl list runtimes` to list the runtimes existing on your
+  /// MacOs. If runtime derived from [majorVersion] and [minorVersion] is not
+  /// available an exception will be thrown. Use Xcode to install more versions.
+  ///
+  /// [device] example iPhone 11 Pro. Run `xcrun simctl list devicetypes` to
+  /// list the devidetypes available. If [device] is not available, an
+  /// exception will be thrown. Use Xcode to install more versions.
+  ///
+  /// Use `xcrun simctl create --help` for more details.
+  Future<IosSimulator> createSimulator(
+      int majorVersion, int minorVersion, String device) async {
+    final String runtime = 'iOS ${majorVersion}.${minorVersion}';
+
+    // Check if the runtime is available.
+    final io.ProcessResult runtimeListResult =
+        await io.Process.run('xcrun', ['simctl', 'list', 'runtimes']);
+
+    if (runtimeListResult.exitCode != 0) {
+      throw Exception('Failed to boot list runtimes(versions). Command used: '
+          'xcrun simctl list runtimes');
+    }
+
+    final String output = runtimeListResult.stdout as String;
+    if (!output.contains(runtime)) {
+      throw Exception('Mac does not have the requested $runtime '
+          'available for simulators. Please use XCode to install.');
+    }
+
+    // Check if the device is available.
+    final io.ProcessResult deviceListResult =
+        await io.Process.run('xcrun', ['simctl', 'list', 'devicetypes']);
+
+    if (deviceListResult.exitCode != 0) {
+      throw Exception('Failed to boot list available simulator device types.'
+          'Command used: xcrun simctl list devicetypes');
+    }
+
+    final String deviceListOutput = deviceListResult.stdout as String;
+    if (!deviceListOutput.contains(device)) {
+      throw Exception('Mac does not have the requested device type $device '
+          'available for simulators. Please use XCode to install.');
+    }
+
+    // Prepate device type argument. It should look like:
+    // com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro
+    final String deviceTypeAsArg =
+        'com.apple.CoreSimulator.SimDeviceType.${device.replaceAll(' ', '-')}';
+
+    // Prepare runtime as argument using the versions. It should look like:
+    // com.apple.CoreSimulator.SimRuntime.iOS-13-1.
+    final String runtimeTypeAsArg =
+        'com.apple.CoreSimulator.SimRuntime.iOS-${majorVersion}-${minorVersion}';
+
+    final io.ProcessResult createResult = await io.Process.run('xcrun',
+        ['simctl', 'create', device, deviceTypeAsArg, runtimeTypeAsArg]);
+
+    if (createResult.exitCode != 0) {
+      throw Exception('Failed to create requested simulator using $device '
+          '$deviceTypeAsArg $runtimeTypeAsArg arguments.');
+    }
+
+    // Output will have the simulator id.
+    final String simulatorId = createResult.stdout as String;
+    return IosSimulator(false, simulatorId.trim());
+  }
+
+  /// Boots the iOS Simulator that's id is given.
+  ///
+  /// Uses `xcrun simctl boot` command to boot an iOS Simulator.
+  ///
+  /// If it is already booted the command will fail.
+  Future<void> bootSimulator(String simulatorId) async {
+    final io.ProcessResult versionResult =
+        await io.Process.run('xcrun', ['simctl', 'boot', '$simulatorId']);
+
+    if (versionResult.exitCode != 0) {
+      throw Exception('Failed to boot iOS simulators with id: $simulatorId.');
+    }
+
+    return;
+  }
+
+  /// Shutsdown the iOS Simulator that's id is given.
+  ///
+  /// Uses `xcrun simctl shutdown` command to boot an iOS Simulator.
+  ///
+  /// If the simulator is not booted, the command will fail.
+  Future<void> shutdownSimulator(String simulatorId) async {
+    final io.ProcessResult versionResult =
+        await io.Process.run('xcrun', ['simctl', 'shutdown', '$simulatorId']);
+
+    if (versionResult.exitCode != 0) {
+      throw Exception(
+          'Failed to shutdown iOS simulators with id: $simulatorId.');
+    }
+
+    return;
+  }
+
+  Future<IosSimulator> getSimulatorInfo(
+      int osMajorVersion, int osMinorVersion, String phone) async {
+    final String simulatorVersion =
+        '-- iOS ${osMajorVersion}.${osMinorVersion} --';
+    final String simulatorsList =
+        await listExistingSimulators(osMajorVersion, osMinorVersion);
+
+    // The simulator list, have the version string followed by a list of phone
+    // names along with their ids and their statuses. Example output:
+    // -- iOS 13.5 --
+    //   iPhone 8 (2A437C91-3B85-4D7B-BB91-32561DA07B85) (Shutdown)
+    //   iPhone 8 Plus (170207A8-7631-4CBE-940E-86A7815AEB2B) (Shutdown)
+    //   iPhone 11 (7AEC5FB9-E08A-4F7F-8CA2-1518CE3A3E0D) (Booted)
+    //   iPhone 11 Pro (D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC) (Shutdown)
+    //   iPhone 11 Pro Max (3F33AD9A-805E-43E0-A86C-8FC70464A390) (Shutdown)
+    // -- iOS 13.6 --
+    //   iPhone 8 (2A437C91-3B85-4D7B-BB91-32561DA07B85) (Shutdown)
+    //   iPhone 8 Plus (170207A8-7631-4CBE-940E-86A7815AEB2B) (Shutdown)
+    //   iPhone 11 (7AEC5FB9-E08A-4F7F-8CA2-1518CE3A3E0D) (Booted)
+    //   iPhone 11 Pro (D8074C8B-35A5-4DA5-9AB2-4CE738A5E5FC) (Shutdown)
+    final int indexOfVersionListStart =
+        simulatorsList.indexOf(simulatorVersion);
+    final String restOfTheOutput = simulatorsList
+        .substring(indexOfVersionListStart + simulatorVersion.length);
+    final int indexOfNextVersion = restOfTheOutput.indexOf('--');
+    final String listOfPhones =
+        restOfTheOutput.substring(0, indexOfNextVersion);
+
+    final int indexOfPhone = listOfPhones.indexOf(phone);
+    if (indexOfPhone == -1) {
+      throw Exception('Simulator of $phone is not available for iOS version '
+          '${osMajorVersion}.${osMinorVersion}');
+    }
+
+    final String phoneInfo = listOfPhones.substring(indexOfPhone);
+    final int endIndexOfPhoneId = phoneInfo.indexOf(')');
+    final String simulatorId =
+        phoneInfo.substring(phoneInfo.indexOf('(') + 1, endIndexOfPhoneId);
+
+    final String phoneInfoAfterId = phoneInfo.substring(endIndexOfPhoneId + 1);
+    final String simulatorStatus = phoneInfoAfterId.substring(
+        phoneInfoAfterId.indexOf('(') + 1, phoneInfoAfterId.indexOf(')'));
+    return IosSimulator(simulatorStatus == 'Booted', simulatorId);
+  }
+
+  Future<String> listExistingSimulators(
+      int osMajorVersion, int osMinorVersion) async {
+    final io.ProcessResult versionResult =
+        await io.Process.run('xcrun', ['simctl', 'list']);
+
+    if (versionResult.exitCode != 0) {
+      throw Exception('Failed to list iOS simulators.');
+    }
+    final String output = versionResult.stdout as String;
+    // If the requested iOS version simulators exists, there should be a block
+    // starting with: `-- iOS osMajorVersion.osMinorVersion --`
+    final bool versionCheck =
+        output.contains('-- iOS ${osMajorVersion}.${osMinorVersion} --');
+
+    if (!versionCheck) {
+      throw Exception(
+          'Requested simulator version iOS ${osMajorVersion}.${osMinorVersion} '
+          'is not available.');
+    }
+
+    return output;
+  }
+}
+
+class IosSimulator {
+  final bool booted;
+  final String id;
+  IosSimulator(this.booted, this.id);
+
+  @override
+  String toString() {
+    return 'Simulator id: $id status: $booted';
+  }
+}

--- a/packages/simulators/pubspec.yaml
+++ b/packages/simulators/pubspec.yaml
@@ -1,0 +1,5 @@
+name: simulators
+description: For creating and managing iOS simulators.
+
+environment:
+  sdk: ">=2.2.2 <3.0.0"


### PR DESCRIPTION
This PR will provide a library to manage the iOS simulator. It can be used by the other places which needs to control the simulators.

Another PR:https://github.com/flutter/engine/pull/18650 adds support for iOS web engine unit tests only if a simulator exits and booted. Using this library we can change felt to:
1) Check the existing simulators
2) Create one if not available
3) Boot the simulator
4) Run the ios web tests (PR:https://github.com/flutter/engine/pull/18650)
5) shutdown the simulator.
