### PR TITLE
add support for firefox driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.packages
 *pubspec.lock
 chromedriver
+firefoxdriver
 .DS_Store

--- a/packages/web_drivers/README.md
+++ b/packages/web_drivers/README.md
@@ -30,3 +30,21 @@ This will end with an error if the exiting version differs from the system versi
 **No-options also currently defaults to install and start Chrome Driver. It will be deprecated soon.**
 
 ```dart lib/web_driver_installer.dart &```
+
+**For Firefox Driver**
+
+To install and keep running:
+
+```dart lib/web_driver_installer.dart firefoxdriver&```
+
+Firefox uses gecko driver. The default is taken from driver_version.yaml file.
+One can provide different release versions for gecko driver.
+For releases see: https://github.com/mozilla/geckodriver/releases
+
+```dart lib/web_driver_installer.dart firefoxdriver --driver-version="v0.25.0"```
+
+`always-install` and `install-only` commands can still be used for Firefox.
+
+```dart lib/web_driver_installer.dart chromedriver --always-install```
+
+```dart lib/web_driver_installer.dart chromedriver --install-only```

--- a/packages/web_drivers/README.md
+++ b/packages/web_drivers/README.md
@@ -43,7 +43,7 @@ For releases see: https://github.com/mozilla/geckodriver/releases
 
 ```dart lib/web_driver_installer.dart firefoxdriver --driver-version="v0.25.0"```
 
-`always-install` and `install-only` commands can still be used for Firefox.
+Note that `always-install` and `install-only` commands can still be used for Firefox.
 
 ```dart lib/web_driver_installer.dart chromedriver --always-install```
 

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -11,3 +11,7 @@ chrome:
   76: '76.0.3809.126'
   75: '75.0.3770.140'
   74: '74.0.3729.6'
+## geckodriver is used for testing Firefox Browser. It works with multiple
+## Firefox Browser versions.
+## See: https://github.com/mozilla/geckodriver/releases
+gecko: 'v0.26.0'

--- a/packages/web_drivers/lib/chrome_driver_command.dart
+++ b/packages/web_drivers/lib/chrome_driver_command.dart
@@ -13,19 +13,18 @@ class ChromeDriverCommand extends Command<bool> {
   @override
   String get name => 'chromedriver';
 
-  final String defaultDriverVersion = 'fromlockfile';
+  static const String defaultDriverVersion = 'fromlockfile';
 
   ChromeDriverCommand() {
     argParser
       ..addFlag('always-install',
           defaultsTo: false,
-          help: 'There might be an already installed version of the driver. '
-              'If one wants to overwrite it, set this flag')
-      ..addFlag(
-        'install-only',
-        defaultsTo: false,
-        help: 'Only installs the driver. Does not start it. Default is false',
-      )
+          help: 'Overwrites an existing driver installation, if any. There '
+              'might be an already installed version of the driver. This '
+              'flag will delete it before installing a new one.')
+      ..addFlag('install-only',
+          defaultsTo: false,
+          help: 'Only installs the driver. Does not start it. Default is false')
       ..addOption('driver-version',
           defaultsTo: defaultDriverVersion,
           help: 'Install the given version of the driver. If driver version is '

--- a/packages/web_drivers/lib/firefox_driver_command.dart
+++ b/packages/web_drivers/lib/firefox_driver_command.dart
@@ -2,36 +2,37 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:args/command_runner.dart';
 import 'package:web_driver_installer/firefox_driver_installer.dart';
 
 /// Wrapper class on top of [FirefoxDriverInstaller] to use it as a command.
-class FirefoxriverCommand extends Command<bool> {
+class FirefoxDriverCommand extends Command<bool> {
   @override
   String get description => 'Firefox Driver installer.';
 
   @override
   String get name => 'firefoxdriver';
 
-  final String defaultDriverVersion = 'fromlockfile';
+  static const String defaultDriverVersion = 'fromlockfile';
 
-  FirefoxriverCommand() {
+  FirefoxDriverCommand() {
     argParser
       ..addFlag('always-install',
           defaultsTo: false,
-          help: 'There might be an already installed version of the driver. '
-              'If one wants to overwrite it, set this flag')
-      ..addFlag(
-        'install-only',
-        defaultsTo: false,
-        help: 'Only installs the driver. Does not start it. Default is false',
-      )
+          help: 'Overwrites an existing driver installation, if any. There '
+              'might be an already installed version of the driver. This '
+              'flag will delete it before installing a new one.')
+      ..addFlag('install-only',
+          defaultsTo: false,
+          help: 'Only installs the driver. Does not start it. Default is false')
       ..addOption('driver-version',
           defaultsTo: defaultDriverVersion,
           help: 'Install the given release from the geckodriver releases. If '
-          'release version is not provided use version from the '
-          'driver_version.yaml. For releases see: '
-          'https://github.com/mozilla/geckodriver/releases');
+              'release version is not provided use version from the '
+              'driver_version.yaml. For releases see: '
+              'https://github.com/mozilla/geckodriver/releases');
   }
 
   /// If the gecko driver release version is provided as an argument,
@@ -56,8 +57,7 @@ class FirefoxriverCommand extends Command<bool> {
       }
       return true;
     } catch (e) {
-      print('Exception during install $e');
-      return false;
+      throw Exception('Exception during Firefox command: $e');
     }
   }
 

--- a/packages/web_drivers/lib/firefox_driver_command.dart
+++ b/packages/web_drivers/lib/firefox_driver_command.dart
@@ -1,0 +1,73 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:web_driver_installer/firefox_driver_installer.dart';
+
+/// Wrapper class on top of [FirefoxDriverInstaller] to use it as a command.
+class FirefoxriverCommand extends Command<bool> {
+  @override
+  String get description => 'Firefox Driver installer.';
+
+  @override
+  String get name => 'firefoxdriver';
+
+  final String defaultDriverVersion = 'fromlockfile';
+
+  FirefoxriverCommand() {
+    argParser
+      ..addFlag('always-install',
+          defaultsTo: false,
+          help: 'There might be an already installed version of the driver. '
+              'If one wants to overwrite it, set this flag')
+      ..addFlag(
+        'install-only',
+        defaultsTo: false,
+        help: 'Only installs the driver. Does not start it. Default is false',
+      )
+      ..addOption('driver-version',
+          defaultsTo: defaultDriverVersion,
+          help: 'Install the given release from the geckodriver releases. If '
+          'release version is not provided use version from the '
+          'driver_version.yaml. For releases see: '
+          'https://github.com/mozilla/geckodriver/releases');
+  }
+
+  /// If the gecko driver release version is provided as an argument,
+  /// initialize using it otherwise use the one from  `driver_version.yaml`
+  /// file.
+  ///
+  /// See [_initializeFirefoxDriverInstaller].
+  FirefoxDriverInstaller firefoxDriverInstaller;
+
+  @override
+  Future<bool> run() async {
+    final bool installOnly = argResults['install-only'];
+    final bool alwaysInstall = argResults['always-install'];
+
+    _initializeFirefoxDriverInstaller();
+
+    try {
+      if (installOnly) {
+        await firefoxDriverInstaller.install(alwaysInstall: alwaysInstall);
+      } else {
+        await firefoxDriverInstaller.start(alwaysInstall: alwaysInstall);
+      }
+      return true;
+    } catch (e) {
+      print('Exception during install $e');
+      return false;
+    }
+  }
+
+  void _initializeFirefoxDriverInstaller() {
+    final String driverVersion = argResults['driver-version'];
+    if (driverVersion == defaultDriverVersion) {
+      firefoxDriverInstaller = FirefoxDriverInstaller();
+    } else {
+      firefoxDriverInstaller =
+          FirefoxDriverInstaller(geckoDriverVersion: driverVersion);
+    }
+  }
+}

--- a/packages/web_drivers/lib/firefox_driver_installer.dart
+++ b/packages/web_drivers/lib/firefox_driver_installer.dart
@@ -1,0 +1,172 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:http/http.dart';
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
+
+import 'src/common.dart';
+
+class FirefoxDriverInstaller {
+  /// HTTP client used to download Firefox Driver.
+  final Client client = Client();
+
+  /// Installation directory for Firefox Driver.
+  final io.Directory driverDir = io.Directory('firefoxdriver');
+
+  static const String geckoDriverReleasesUrl =
+      'https://github.com/mozilla/geckodriver/releases/download';
+
+  /// Version of geckodriver release at github.com/mozilla/geckodriver project.
+  ///
+  /// This is not the version of Firefox Browser.
+  ///
+  /// Geckodriver works for multiple versions of Firefox Browser.
+  String geckoDriverVersion;
+
+  FirefoxDriverInstaller({String geckoDriverVersion = ''}) {
+    if (geckoDriverVersion.isEmpty) {
+      print('INFO: No geckoDriverVersion is given. Using geckodriver from '
+          'driver_version.yaml file.');
+      final YamlMap driverLock = DriverLock.instance.configuration;
+      this.geckoDriverVersion = driverLock['gecko'] as String;
+    }
+  }
+
+  io.File driverDownload;
+
+  String get downloadUrl => '$geckoDriverReleasesUrl/${driverUrlPath()}';
+
+  bool get isInstalled => driverDir.existsSync();
+
+  Future<void> start({bool alwaysInstall = false}) async {
+    // Install Driver.
+    try {
+      await install(alwaysInstall: alwaysInstall);
+      await runDriver();
+    } finally {
+      // Only delete if the user is planning to override the installs.
+      // Keeping the existing version might make local development easier.
+      // Also if a CI build runs multiple felt commands using an existing
+      // version speeds up the build.
+      if (!alwaysInstall) {
+        driverDownload?.deleteSync();
+      }
+    }
+  }
+
+  Future<void> install({bool alwaysInstall = false}) async {
+    if (!isInstalled || alwaysInstall) {
+      await _installDriver();
+    } else {
+      print('INFO: Installation skipped. The driver is installed: '
+          '$isInstalled. User requested force install: $alwaysInstall');
+    }
+  }
+
+  Future<void> _installDriver() async {
+    // If this method is called, clean the previous installations.
+    try {
+      driverDownload = await _downloadDriver();
+    } catch (e) {
+      throw Exception(
+          'Failed to download driver Firefox from link $downloadUrl. $e');
+    } finally {
+      client.close();
+    }
+
+    if (io.Platform.isWindows) {
+      await _uncompressWithZip(driverDownload);
+    } else {
+      await _uncompressWithTar(driverDownload);
+    }
+  }
+
+  Future<io.File> _downloadDriver() async {
+    if (driverDir.existsSync()) {
+      driverDir.deleteSync(recursive: true);
+    }
+
+    driverDir.createSync(recursive: true);
+
+    final StreamedResponse download = await client.send(Request(
+      'GET',
+      Uri.parse(downloadUrl),
+    ));
+
+    final io.File downloadedFile =
+        io.File(path.join(driverDir.path, geckoDriverVersion));
+
+    final io.IOSink sink = downloadedFile.openWrite();
+    await download.stream.pipe(sink);
+    await sink.flush();
+    await sink.close();
+
+    return downloadedFile;
+  }
+
+  /// Uncompress the downloaded driver file.
+  Future<void> _uncompressWithZip(io.File downloadedFile) async {
+    final io.ProcessResult unzipResult = await io.Process.run('unzip', <String>[
+      driverDownload.path,
+      '-d',
+      driverDir.path,
+    ]);
+
+    if (unzipResult.exitCode != 0) {
+      throw Exception(
+          'Failed to unzip the downloaded gecko driver ${driverDownload.path}.\n'
+          'With the driver path ${driverDir.path}\n'
+          'The unzip process exited with code ${unzipResult.exitCode}.');
+    }
+  }
+
+  /// Start using firefoxdriver --port=4444
+  Future<io.ProcessResult> runDriver() async {
+    print('INFO: Starting Firefox Driver on port 4444');
+    return await io.Process.run(
+        'firefoxdriver/geckodriver', <String>['--port=4444']);
+  }
+
+  /// Uncompress the downloaded browser files for operating systems that
+  /// use a zip archive.
+  /// See [version].
+  Future<void> _uncompressWithTar(io.File downloadedFile) async {
+    final io.ProcessResult unzipResult = await io.Process.run('tar', <String>[
+      '-x',
+      '-f',
+      downloadedFile.path,
+      '-C',
+      driverDir.path,
+    ]);
+
+    if (unzipResult.exitCode != 0) {
+      throw Exception(
+          'Failed to unzip the downloaded Firefox archive ${downloadedFile.path}.\n'
+          'The unzip process exited with code ${unzipResult.exitCode}.');
+    }
+  }
+
+  /// Driver name for operating system.
+  ///
+  /// Drivers can be found at:
+  /// https://github.com/mozilla/geckodriver/releases/
+  String driverUrlPath() {
+    if (io.Platform.isMacOS) {
+      return '${geckoDriverVersion}/geckodriver-${geckoDriverVersion}-'
+          'macos.tar.gz';
+    } else if (io.Platform.isLinux) {
+      return '${geckoDriverVersion}/geckodriver-${geckoDriverVersion}-'
+          'linux64.tar.gz';
+    } else if (io.Platform.isWindows) {
+      return '${geckoDriverVersion}/geckodriver-${geckoDriverVersion}-'
+          'win64.zip';
+    } else {
+      throw UnimplementedError('Automated testing not supported on this OS.'
+          'Platform name: ${io.Platform.operatingSystem}');
+    }
+  }
+}

--- a/packages/web_drivers/lib/web_driver_installer.dart
+++ b/packages/web_drivers/lib/web_driver_installer.dart
@@ -16,7 +16,7 @@ CommandRunner runner = CommandRunner<bool>(
       'with flutter driver.',
 )
   ..addCommand(ChromeDriverCommand())
-  ..addCommand(FirefoxriverCommand())
+  ..addCommand(FirefoxDriverCommand())
   ..addCommand(SafariDriverCommand());
 
 void main(List<String> args) async {

--- a/packages/web_drivers/lib/web_driver_installer.dart
+++ b/packages/web_drivers/lib/web_driver_installer.dart
@@ -5,6 +5,7 @@
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
+import 'package:web_driver_installer/firefox_driver_command.dart';
 
 import 'chrome_driver_command.dart';
 import 'safari_driver_command.dart';
@@ -15,6 +16,7 @@ CommandRunner runner = CommandRunner<bool>(
       'with flutter driver.',
 )
   ..addCommand(ChromeDriverCommand())
+  ..addCommand(FirefoxriverCommand())
   ..addCommand(SafariDriverCommand());
 
 void main(List<String> args) async {


### PR DESCRIPTION
Add support for firefox driver, this will be used in cirrus and in local. I already added a CIPD package for LUCI usage.

For issue https://github.com/flutter/flutter/issues/59650