### PR TITLE
new driver versions are added to chromedriver.chromium.org

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,8 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  85: '85.0.4183.38'
+  84: '84.0.4147.30'
   83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'


### PR DESCRIPTION
We are using the recommended drivers from chromedriver.chromium.org/downloads to run the flutter driver based tests. 

There are two new versions added. This PR adds them to web installers.