### PR TITLE
Add chrome driver 89.0.4389.23.

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  89: '89.0.4389.23'
   88: '88.0.4324.96'
   87: '87.0.4280.88'
   86: '86.0.4240.22'


### PR DESCRIPTION
This is to fix web_smoke_tests failing with:
   Exception during install Exception: No known chromedriver version for Chrome version 89.