### PR TITLE
Add chrome driver version for chrome 90.

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  90: '90.0.4430.24'
   89: '89.0.4389.23'
   88: '88.0.4324.96'
   87: '87.0.4280.88'


### PR DESCRIPTION
This is to unblock Cirrus tests building a new docker image.