### PR TITLE
Add driver mappings for chrome 98, 100, 101, 102, 103, 104, 105.

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,8 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  111: '111.0.5563.19'
+  110: '110.0.5481.77'
   109: '109.0.5414.25'
   108: '108.0.5359.71'
   107: '107.0.5304.62'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  102: '102.0.5005.61'
   101: '101.0.4951.41'
   100: '100.0.4896.60'
   98: '98.0.4758.102'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  98: '98.0.4758.102'
   97: '97.0.4692.71'
   95: '95.0.4638.10'
   94: '94.0.4606.41'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,9 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  109: '109.0.5414.25'
+  108: '108.0.5359.71'
+  107: '107.0.5304.62'
   106: '106.0.5249.61'
   105: '105.0.5195.19'
   104: '104.0.5112.79'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  101: '101.0.4951.41'
   100: '100.0.4896.60'
   98: '98.0.4758.102'
   97: '97.0.4692.71'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,9 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  105: '105.0.5195.19'
+  104: '104.0.5112.79'
+  103: '103.0.5060.134'
   102: '102.0.5005.61'
   101: '101.0.4951.41'
   100: '100.0.4896.60'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  100: '100.0.4896.60'
   98: '98.0.4758.102'
   97: '97.0.4692.71'
   95: '95.0.4638.10'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,8 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  113: '113.0.5672.24'
+  112: '112.0.5615.49'
   111: '111.0.5563.19'
   110: '110.0.5481.77'
   109: '109.0.5414.25'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  106: '106.0.5249.61'
   105: '105.0.5195.19'
   104: '104.0.5112.79'
   103: '103.0.5060.134'


### PR DESCRIPTION
- add support for chrome 98, 100, 101, 102, 103, 104, and 105 drivers (similar to #31)
  - issues are disabled for the repo so I didn't create one

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
