### PR TITLE
feat: use new chromedriver download urls if possible.

### DIFF
--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,8 +2,6 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
-  116: '116.0.5845.96'
-  115: '115.0.5790.90'
   114: '114.0.5735.90'
   113: '113.0.5672.63'
   112: '112.0.5615.49'

--- a/packages/web_drivers/driver_version.yaml
+++ b/packages/web_drivers/driver_version.yaml
@@ -2,6 +2,8 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  116: '116.0.5845.96'
+  115: '115.0.5790.90'
   114: '114.0.5735.90'
   113: '113.0.5672.63'
   112: '112.0.5615.49'

--- a/packages/web_drivers/lib/chrome_driver_installer.dart
+++ b/packages/web_drivers/lib/chrome_driver_installer.dart
@@ -241,15 +241,13 @@ class ChromeDriverInstaller {
       return;
     }
     actualDriverDir = entries.whereType<io.Directory>().first;
-    
   }
 
   Future<void> runDriver() async {
-    if (io.Directory('chromedriver').existsSync()) {
-      //use old structure
-      await io.Process.run(
-          'chromedriver/chromedriver', <String>['--port=4444']);
-    } else {}
+    await io.Process.run(
+      installation.absolute.path,
+      <String>['--port=4444'],
+    );
   }
 
   /// Driver name for operating system.


### PR DESCRIPTION
The chromedriver >= 115 urls have changed, according to https://chromedriver.chromium.org/downloads
the new urls are now in: https://googlechromelabs.github.io/chrome-for-testing/
this PR tries to query for the new urls first, and if it fails, falls back to the old urls.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
